### PR TITLE
修改大图片超过屏幕高宽情况的适配

### DIFF
--- a/src/extend/layer.ext.js
+++ b/src/extend/layer.ext.js
@@ -211,9 +211,15 @@ layer.photos = function(options, loop, key){
             area: function(){
                var imgarea = [img.width, img.height];
                var winarea = [$(window).width() - 100, $(window).height() - 100];
-               if(!options.full && imgarea[0] > winarea[0]){
-                   imgarea[0] = winarea[0];
-                   imgarea[1] = imgarea[0]*winarea[1]/imgarea[0];
+               if(!options.full){
+            	   if(imgarea[0] > winarea[0]){
+            		   imgarea[1] = imgarea[1] * winarea[0] / imgarea[0];
+            		   imgarea[0] = winarea[0];
+            	   }
+            	   if(imgarea[1] > winarea[1]){
+            		   imgarea[0] = imgarea[0] * winarea[1] / imgarea[1];
+            		   imgarea[1] = winarea[1];
+            	   }  
                }
                return [imgarea[0]+'px', imgarea[1]+'px']; 
             }(),


### PR DESCRIPTION
之前的代码只处理了超过宽度的情况，而且不是等比缩放，实际效果会使图片底部遮挡一节。
这部分改动为先判断宽度如果超过，处理缩放。如果处理之后高度还超过实际高度，就在按照高度缩放。